### PR TITLE
Added entries for centos base image

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -196,7 +196,16 @@ Projects:
     notify-email : mohammed.zee1000@gmail.com
     depends-on   : null
 
-# CentOS Dockerfiles (Reserved 501-1000)
+# CentOS Dockerfiles (Reserved 500-1000)
+  - id           : 500
+    app-id       : centos
+    job-id       : centos
+    git-url      : https://github.com/CentOS/sig-cloud-instance-images
+    git-path     : docker
+    git-branch   : CentOS-7
+    target-file  : Dockerfile
+    notify-email : bamachrn@gmail.com
+    depends-on   : null
 
   - id           : 501
     app-id       : centos


### PR DESCRIPTION
* This entry is for getting centos base image built and pushed to registry.centos.org
* Image will be pushed with name centos/centos:latest