### PR TITLE
Adds a new scanner image to CCCP index

### DIFF
--- a/index.d/pipeline-images.yml
+++ b/index.d/pipeline-images.yml
@@ -64,3 +64,14 @@
     desired-tag: latest
     notify-email: shahdharmit@gmail.com
     depends-on: null
+
+  - id: 7
+    app-id: pipeline-images
+    job-id: scanner-rpm-verify
+    git-url: https://github.com/CentOS/container-pipeline-service
+    git-branch: master
+    git-path: /atomic_scanners/scanner-rpm-verify/
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: shaikhnavid14@gmail.com
+    depends-on: null


### PR DESCRIPTION
This PR adds a new container image to CCCP index. The image is an atomic scanner, namely `scanner-rpm-verify`.  It checks verifies and reports the problems with installed RPM packages and their files in given image under test.