### PR TITLE
request kbsingh/openshift-nginx to build queue

### DIFF
--- a/index.d/kbsingh.yml
+++ b/index.d/kbsingh.yml
@@ -1,0 +1,12 @@
+Projects:
+  - id: 1
+    app-id: kbsingh
+    job-id: openshift-nginx
+    git-url: https://github.com/kbsingh/openshift-nginx
+    git-branch: master
+    git-path: /
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: cp.build.inb@karan.org
+    depends-on: null
+  


### PR DESCRIPTION
this re-implements the CentOS-Dockerfile nginx, in a way that it can run on an openshift platform