### PR TITLE
change job id for centos_go to centos-go and centos_jre to centos-jre

### DIFF
--- a/index.d/dharmit.yml
+++ b/index.d/dharmit.yml
@@ -1,7 +1,7 @@
 Projects:
   - id: 1
     app-id: dharmit
-    job-id: centos_jre
+    job-id: centosi-jre
     git-url: https://github.com/dharmit/dockerfiles
     git-branch: centos-dockerfiles
     git-path: centos_jre
@@ -12,7 +12,7 @@ Projects:
   
   - id: 2
     app-id: dharmit
-    job-id: centos_go
+    job-id: centos-go
     git-url: https://github.com/dharmit/dockerfiles
     git-branch: centos-dockerfiles
     git-path: centos_go


### PR DESCRIPTION
fix's https://github.com/CentOS/container-index/issues/57 