### PR TITLE
Add a docker image for beanstalkd

### DIFF
--- a/index.d/dries.yml
+++ b/index.d/dries.yml
@@ -9,4 +9,15 @@ Projects:
     desired-tag: latest
     notify-email: dries.verachtert@dries.eu
     depends-on: centos/centos:latest
-  
+
+Projects:
+  - id: 2
+    app-id: dries
+    job-id: beanstalkd
+    git-url: https://github.com/driesverachtert/dockerfiles
+    git-branch: master
+    git-path: /beanstalkd
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: dries.verachtert@dries.eu
+    depends-on: centos/centos:latest

--- a/index.d/dries.yml
+++ b/index.d/dries.yml
@@ -1,0 +1,12 @@
+Projects:
+  - id: 1
+    app-id: dries
+    job-id: template-test
+    git-url: https://github.com/driesverachtert/dockerfiles
+    git-branch: master
+    git-path: /template-test
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: dries.verachtert@dries.eu
+    depends-on: centos/centos:latest
+  


### PR DESCRIPTION
A simple docker image that could be used to run beanstalkd