### PR TITLE
Move centos-git container under che-stacks namespace

### DIFF
--- a/index.d/che-stacks.yml
+++ b/index.d/che-stacks.yml
@@ -42,3 +42,14 @@ Projects:
     desired-tag: latest
     notify-email: shahdharmit@gmail.com
     depends-on: centos/centos:latest
+
+  - id: 5
+    app-id: che-stacks
+    job-id: centos-git
+    git-url: https://github.com/eclipse/che-dockerfiles
+    git-branch: master
+    git-path: recipes/centos/
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: shahdharmit@gmail.com
+    depends-on: centos/centos:latest

--- a/index.d/dharmit.yml
+++ b/index.d/dharmit.yml
@@ -65,13 +65,3 @@ Projects:
     notify-email: shahdharmit@gmail.com
     depends-on: centos/centos:latest
 
-  - id: 7
-    app-id: dharmit
-    job-id: centos-git
-    git-url: https://github.com/dharmit/che-dockerfiles
-    git-branch: centos_git
-    git-path: recipes/centos/
-    target-file: Dockerfile
-    desired-tag: latest
-    notify-email: shahdharmit@gmail.com
-    depends-on: centos/centos:latest


### PR DESCRIPTION
This container was under my namepsace earlier. For the stacks, we need to put it under `che-stacks` namepsace.

ping @bamachrn @mohammedzee1000 