### PR TITLE
Update mattermost-openshift to versioned tags

### DIFF
--- a/index.d/mattermost.yml
+++ b/index.d/mattermost.yml
@@ -119,3 +119,14 @@ Projects:
     desired-tag: 3.7
     notify-email: jchevret@redhat.com
     depends-on: centos/centos:7
+    
+  - id: 12
+    app-id: mattermost
+    job-id: mattermost-team
+    git-url: https://github.com/jfchevrette/mattermost-openshift
+    git-branch: master
+    git-path: 3.8/
+    target-file: Dockerfile
+    desired-tag: 3.8
+    notify-email: jchevret@redhat.com
+    depends-on: centos/centos:7

--- a/index.d/mattermost.yml
+++ b/index.d/mattermost.yml
@@ -59,7 +59,7 @@ Projects:
     job-id: mattermost-team
     git-url: https://github.com/jfchevrette/mattermost-openshift
     git-branch: master
-    git-path: mattermost-team
+    git-path: 3.7/
     target-file: Dockerfile
     desired-tag: latest
     notify-email: jchevret@redhat.com
@@ -108,3 +108,14 @@ Projects:
     desired-tag: latest
     notify-email: sgk@redhat.com
     depends-on: centos/centos:latest
+
+  - id: 11
+    app-id: mattermost
+    job-id: mattermost-team
+    git-url: https://github.com/jfchevrette/mattermost-openshift
+    git-branch: master
+    git-path: 3.7/
+    target-file: Dockerfile
+    desired-tag: 3.7
+    notify-email: jchevret@redhat.com
+    depends-on: centos/centos:7


### PR DESCRIPTION
This updates the mattermost-openshift definition to find version 3.7 in 3.7 folder

Version 3.7 remains the one tagged with 'latest'
