### PR TITLE
Added cockpit upstream container images

### DIFF
--- a/index.d/cockpit.yml
+++ b/index.d/cockpit.yml
@@ -25,12 +25,12 @@ Projects:
   - id: 3
     app-id: cockpit
     job-id: ws
-    git-url: https://github.com/CentOS/CentOS-Dockerfiles
+    git-url: https://github.com/cockpit-project/cockpit
     git-branch: master
-    git-path: cockpit/ws
-    target-file: Dockerfile
+    git-path: containers/ws
+    target-file: Dockerfile.centos7
     desired-tag: latest
-    notify-email: mohammed.zee1000@gmail.com
+    notify-email: pvolpe@redhat.com
     depends-on: centos/centos:latest
 
   - id: 4
@@ -42,4 +42,15 @@ Projects:
     target-file: Dockerfile.testing
     desired-tag: testing
     notify-email: mohammed.zee1000@gmail.com
+    depends-on: centos/centos:latest
+
+  - id: 5
+    app-id: cockpit
+    job-id: kubernetes
+    git-url: https://github.com/cockpit-project/cockpit
+    git-branch: master
+    git-path: containers/kubernetes
+    target-file: Dockerfile.centos7
+    desired-tag: upstream
+    notify-email: pvolpe@redhat.com
     depends-on: centos/centos:latest


### PR DESCRIPTION
* Pointed cockpit containers to get built from the upstream cockpit repo.
     * replaced cockpit/ws:latest with upstream one as it is building without any errors.
     * created one more entry for `cockpit/kubernetes:upstream`. this image is having build time erros so did not replace the latest built from centos-dockerfiles.