### PR TITLE
Base image to be used by other images to build on top of

### DIFF
--- a/index.d/dharmit.yml
+++ b/index.d/dharmit.yml
@@ -86,3 +86,14 @@ Projects:
     desired-tag: 3.5
     notify-email: shahdharmit@gmail.com
     depends-on: centos/centos:latest
+
+  - id: 11
+    app-id: dharmit
+    job-id: base
+    git-url: https://github.com/dharmit/dockerfiles
+    git-branch: master
+    git-path: /base
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: shahdharmit@gmail.com
+    depends-on: centos/centos:latest


### PR DESCRIPTION
ping @bamachrn @mohammedzee1000 this is for the languages/framework images that we plan to add. Taking a cue from images built for Che stacks, I've prepared an image that will have basic packages installed and configurations done so that we can just build on top of it. 