### PR TITLE
Add CentOS base image (`centos-stack-base`) for Che stacks

### DIFF
--- a/index.d/che-stacks.yml
+++ b/index.d/che-stacks.yml
@@ -45,10 +45,10 @@ Projects:
 
   - id: 5
     app-id: che-stacks
-    job-id: centos-git
+    job-id: centos-jdk8
     git-url: https://github.com/eclipse/che-dockerfiles
     git-branch: master
-    git-path: recipes/centos/
+    git-path: recipes/centos_jdk8/
     target-file: Dockerfile
     desired-tag: latest
     notify-email: shahdharmit@gmail.com

--- a/index.d/che-stacks.yml
+++ b/index.d/che-stacks.yml
@@ -86,3 +86,14 @@ Projects:
     desired-tag: latest
     notify-email: shahdharmit@gmail.com
     depends-on: centos/centos:latest
+
+  - id: 9
+    app-id: che-stacks
+    job-id: centos-stack-base
+    git-url: https://github.com/eclipse/che-dockerfiles
+    git-branch: master
+    git-path: recipes/stack-base/centos
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: shahdharmit@gmail.com
+    depends-on: centos/centos:latest


### PR DESCRIPTION
A new base image for Che stacks has been added via https://github.com/eclipse/che-dockerfiles/pull/127. This new entry corresponds to it.

ping @bamachrn @mohammedzee1000 