### PR TITLE
Change `depends-on` for che-stacks images to sync with upstream repo

### DIFF
--- a/index.d/che-stacks.yml
+++ b/index.d/che-stacks.yml
@@ -8,7 +8,7 @@ Projects:
     target-file: Dockerfile
     desired-tag: latest
     notify-email: shahdharmit@gmail.com
-    depends-on: centos/centos:latest
+    depends-on: che-stacks/centos-jdk8:latest
 
   - id: 2
     app-id: che-stacks
@@ -19,7 +19,7 @@ Projects:
     target-file: Dockerfile
     desired-tag: latest
     notify-email: shahdharmit@gmail.com
-    depends-on: centos/centos:latest
+    depends-on: che-stacks/centos-jdk8:latest
 
   - id: 3
     app-id: che-stacks
@@ -30,7 +30,7 @@ Projects:
     target-file: Dockerfile
     desired-tag: latest
     notify-email: shahdharmit@gmail.com
-    depends-on: centos/centos:latest
+    depends-on: che-stacks/centos-jdk8:latest
 
   - id: 4
     app-id: che-stacks


### PR DESCRIPTION
I missed making this change when I went through https://github.com/eclipse/che-dockerfiles/pull/127/ earlier.