### PR TITLE
Change tag and base image for golang image

### DIFF
--- a/index.d/dharmit.yml
+++ b/index.d/dharmit.yml
@@ -52,18 +52,18 @@ Projects:
     target-file: Dockerfile
     desired-tag: 1.6
     notify-email: shahdharmit@gmail.com
-    depends-on: centos/centos:latest
+    depends-on: dharmit/base:latest
 
   - id: 8
     app-id: dharmit
     job-id: golang
     git-url: https://github.com/dharmit/dockerfiles
     git-branch: master
-    git-path: /golang/1.7/
+    git-path: /golang/1.8/
     target-file: Dockerfile
-    desired-tag: 1.7
+    desired-tag: 1.8
     notify-email: shahdharmit@gmail.com
-    depends-on: centos/centos:latest
+    depends-on: dharmit/base:latest
 
   - id: 9
     app-id: dharmit


### PR DESCRIPTION
`centosplus` repo's got newer version of `golang`. `1.7` -> `1.8.3`. This PR syncs image with the change.