### PR TITLE
Fix .NET builder image dependency.

### DIFF
--- a/index.d/dotnet.yml
+++ b/index.d/dotnet.yml
@@ -21,4 +21,4 @@ Projects:
     notify-email: omajid@redhat.com
     depends-on:
        - centos/centos:latest
-       - centos/dotnet-20-runtime-centos7:latest
+       - dotnet/dotnet-20-runtime-centos7:latest


### PR DESCRIPTION
Use correct image:

dotnet/dotnet-20-runtime-centos7

vs.

centos/dotnet-20-runtime-centos7