### PR TITLE
Fix che-stacks/centos-dotnet20 description

### DIFF
--- a/index.d/che-stacks.yml
+++ b/index.d/che-stacks.yml
@@ -112,8 +112,8 @@ Projects:
   - id: 12
     app-id: che-stacks
     job-id: centos-dotnet20
-    git-url: https://github.com/dharmit/che-dockerfiles
-    git-branch: centos-dotnet-20
+    git-url: https://github.com/eclipse/che-dockerfiles
+    git-branch: master
     git-path: recipes/centos_dotnet20
     target-file: Dockerfile
     desired-tag: latest


### PR DESCRIPTION
The stack definition still pointed to @dharmit github repository