### PR TITLE
projectatomic: Add the CRI-O and Docker system containers

### DIFF
--- a/index.d/projectatomic.yml
+++ b/index.d/projectatomic.yml
@@ -23,3 +23,15 @@ Projects:
     notify-email: gscrivan@redhat.com
     depends-on:
       - centos/centos:latest
+
+  - id: 3
+    app-id: projectatomic
+    job-id: docker
+    git-url: https://github.com/projectatomic/atomic-system-containers
+    git-branch: master
+    git-path: /docker-centos
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: gscrivan@redhat.com
+    depends-on:
+      - centos/centos:latest

--- a/index.d/projectatomic.yml
+++ b/index.d/projectatomic.yml
@@ -11,3 +11,15 @@ Projects:
     depends-on:
       - centos/centos:latest 
         #      - openshift/origin:latest
+
+  - id: 2
+    app-id: projectatomic
+    job-id: cri-o
+    git-url: https://github.com/projectatomic/atomic-system-containers
+    git-branch: master
+    git-path: /cri-o-centos
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: gscrivan@redhat.com
+    depends-on:
+      - centos/centos:latest


### PR DESCRIPTION
They are maintained here:

https://github.com/projectatomic/atomic-system-containers/tree/master/cri-o-centos

and

https://github.com/projectatomic/atomic-system-containers/tree/master/docker-centos