### PR TITLE
Remove references to rtnpro's email address from container index

### DIFF
--- a/index.d/centos.yml
+++ b/index.d/centos.yml
@@ -465,7 +465,7 @@ Projects:
     git-branch: master
     target-file: Dockerfile.centos
     desired-tag: 8.17
-    notify-email: rtnpro@redhat.com
+    notify-email: container-status-report@centos.org
     depends-on: centos/centos:latest
 
   - id: 43
@@ -476,7 +476,7 @@ Projects:
     git-branch: master
     target-file: Dockerfile.centos
     desired-tag: 8.18
-    notify-email: rtnpro@redhat.com
+    notify-email: container-status-report@centos.org
     depends-on: centos/centos:latest
 
   - id: 44


### PR DESCRIPTION
@bamachrn @mohammedzee1000 this is half the work done. Other half would be to fork sentry repo into our namespace.