### PR TITLE
Add fabric8 hdd supervisor to centos index

### DIFF
--- a/index.d/fabric8-hdd.yml
+++ b/index.d/fabric8-hdd.yml
@@ -1,0 +1,11 @@
+Projects:
+  - id: 1
+    app-id: fabric8-hdd
+    job-id: openshift-hdd-supervisor
+    git-url: https://github.com/fabric8-hdd/supervisor
+    git-branch: master
+    git-path: /
+    target-file: Dockerfile
+    desired-tag: 1.0.0
+    notify-email: anbabu@redhat.com
+    depends-on: centos/centos:latest


### PR DESCRIPTION
Add fabric8 hdd supervisor to centos index

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>