### PR TITLE
Build dockerfile linter worker image

### DIFF
--- a/index.d/pipeline-images.yml
+++ b/index.d/pipeline-images.yml
@@ -118,5 +118,5 @@ Projects:
     target-file: Dockerfile.linter
     desired-tag: latest
     notify-email: shahdharmit@gmail.com
-    depends-on: dharmit/base
+    depends-on: dharmit/base:latest
     build_context: ./

--- a/index.d/pipeline-images.yml
+++ b/index.d/pipeline-images.yml
@@ -108,3 +108,15 @@ Projects:
     desired-tag: v2
     notify-email: bamachrn@gmail.com
     depends-on: centos/centos:latest
+
+  - id: 11
+    app-id: pipeline-images
+    job-id: dockerfile-lint-worker
+    git-url: https://github.com/dharmit/container-pipeline-service
+    git-path: /server
+    git-branch: fix-osio-1378
+    target-file: Dockerfile.linter
+    desired-tag: latest
+    notify-email: shahdharmit@gmail.com
+    depends-on: dharmit/base
+    build_context: ./


### PR DESCRIPTION
At the moment it's referring to my fork because we haven't merged code in upstream master. Once this is merged and the image is built, CI check for Dockerfile linter worker containerization can happen smoothly.

ping @mohammedzee1000 @bamachrn 