### PR TITLE
Adds minimal golang container for CI testing

### DIFF
--- a/index.d/nshaikh.yml
+++ b/index.d/nshaikh.yml
@@ -9,3 +9,15 @@ Projects:
     desired-tag: latest
     notify-email: container-status-report@centos.org
     depends-on: centos/centos:latest
+
+  - id: 2
+    app-id: nshaikh
+    job-id: go-helloworld
+    git-url: https://github.com/navidshaikh/minimal-go-container
+    git-branch: master
+    git-path: /
+    target-file: Dockerfile.scratch
+    desired-tag: latest
+    notify-email: shaikhnavid14@gmail.com
+    build-context: ./
+    depends-on: null


### PR DESCRIPTION
Container based on scratch, with 1.55MB image size. This is to speed up build phase time for container in CI testing.