### PR TITLE
Moving atomic container to kbsingh namespace.

### DIFF
--- a/index.d/centos.yml
+++ b/index.d/centos.yml
@@ -1239,18 +1239,18 @@ Projects:
 
 # CentOS Atomic Base Image
 
-  - id: 145
-    app-id: centos
-    job-id: centos7-atomic
-    git-url: https://github.com/kbsingh/atomic-container
-    git-branch: master
-    git-path: /
-    target-file: Dockerfile
-    desired-tag: latest
-    notify-email: moahmed@redhat.com
-    prebuild-script: cccp-prebuild.sh
-    prebuild-context: /
-    build-context: ./
-    depends-on: null
+        #  - id: 145
+        #    app-id: centos
+        #    job-id: centos7-atomic
+        #    git-url: https://github.com/kbsingh/atomic-container
+        #    git-branch: master
+        #    git-path: /
+        #    target-file: Dockerfile
+        #    desired-tag: latest
+        #    notify-email: moahmed@redhat.com
+        #    prebuild-script: cccp-prebuild.sh
+        #    prebuild-context: /
+        #    build-context: ./
+        #    depends-on: null
 # CentOS Atomic Base Image ends
 

--- a/index.d/kbsingh.yml
+++ b/index.d/kbsingh.yml
@@ -96,3 +96,18 @@ Projects:
     build-context: ./
     prebuild-script: pre-build.sh
     prebuild-context: /
+
+  - id: 9
+    app-id: kbsingh
+    job-id: centos7-atomic
+    git-url: https://github.com/kbsingh/atomic-container
+    git-branch: master
+    git-path: /
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: cp.build.inb@karan.org
+    prebuild-script: cccp-prebuild.sh
+    prebuild-context: /
+    build-context: ./
+    depends-on: null
+


### PR DESCRIPTION
This is due to the fact that that the container
is not ready to move to centos namespace.

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>