### PR TITLE
Update address for dotnet container notifications

### DIFF
--- a/index.d/dotnet.yml
+++ b/index.d/dotnet.yml
@@ -7,7 +7,7 @@ Projects:
     git-path: 2.0/runtime
     target-file: Dockerfile
     desired-tag: latest
-    notify-email: omajid@redhat.com
+    notify-email: dotnet-team@redhat.com
     build-context: ./
     depends-on: centos/centos:latest
 
@@ -19,7 +19,7 @@ Projects:
     git-path: 2.0/build
     target-file: Dockerfile
     desired-tag: latest
-    notify-email: omajid@redhat.com
+    notify-email: dotnet-team@redhat.com
     build-context: ./
     depends-on:
        - centos/centos:latest
@@ -33,7 +33,7 @@ Projects:
     git-path: 2.0/
     target-file: Dockerfile
     desired-tag: latest
-    notify-email: omajid@redhat.com
+    notify-email: dotnet-team@redhat.com
     build-context: ./
     depends-on:
        - openshift/jenkins-slave-base-centos7:latest


### PR DESCRIPTION
Instead of having me be the primary contact, send all dotnet container notifications to an alias that is read by multiple people. This lets me go on vacation without worrying that no one will see container build errors.