### PR TITLE
Remove unused keys in cccp.yml example

### DIFF
--- a/cccp.yml
+++ b/cccp.yml
@@ -1,41 +1,11 @@
-# This is for the purpose of building containers on the CentOS Community Container 
-# Pipeline. The containers are built, tested and delivered to registry.centos.org and
-# lifecycled as well. A corresponding entry must exist in the container index itself, 
-# located at https://github.com/CentOS/container-index/tree/master/index.d
-# You can know more at the following links:
-# * https://github.com/CentOS/container-pipeline-service/blob/master/README.md
-# * https://github.com/CentOS/container-index/blob/master/README.rst
-# * https://wiki.centos.org/ContainerPipeline
+# This file is required for the purpose of building a Docker container on CCCP.
+# More information (and a quickstart) found here: https://github.com/CentOS/container-index/pull/265
 
 # This will be part of the name of the container. It should match the job-id in index entry
-job-id: 
-
-#the following are optional, can be left blank
-#defaults, where applicable are filled in
-#nulecule-file   : nulecule
+job-id: containername
 
 # This flag tells the container pipeline to skip user defined tests on their container
-test-skip       : True
+# test-skip: False
 
-# This is path of the script that initiates the user defined tests. It must be able to
-# return an exit code.
-test-script     : null
-
-# This is the path of custom build script.
-build-script    : null
-
-# This is the path of the custom delivery script
-delivery-script : null
-
-# This flag tells the pipeline to deliver this container to docker hub.
-docker-index    : True
-
-# This flag can be used to enable or disable the custom delivery
-custom-delivery : False
-
-# This flag can be used to enable or disable delivery of container to local registry
-local-delivery  : True
-
-Upstreams       :
-        - ref           :
-          url           :
+# This is path of the script that initiates the user defined tests. It must be able to return an exit code.
+# test-script: test-script.sh


### PR DESCRIPTION
There are a lot of keys which are not usable / not in use for CCCP.

Including these unused keys in the example is not needed.

I've updated the cccp.yml example to remove the unused keys.