### PR TITLE
Adds the new registry image to the pipeline

### DIFF
--- a/index.d/pipeline-images.yml
+++ b/index.d/pipeline-images.yml
@@ -155,3 +155,15 @@ Projects:
     notify-email: shaikhnavid14@gmail.com
     depends-on: centos/centos:latest
     build_context: ./
+
+  - id: 14
+    app-id: pipeline-images
+    job-id: reg
+    git-url: https://github.com/cdrage/reg
+    git-branch: master
+    git-path: server
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: bamachrn@gmail.com
+    build-context: ./
+    depends-on: centos/centos:latest


### PR DESCRIPTION
Adds the new registry image to pipeline-images in order to propagate the
new registry.centos.org website.

Must be merged in BEFORE https://github.com/CentOS/container-pipeline-service/pull/455