### PR TITLE
Remove eclipse-che-dev image from container-index

### DIFF
--- a/index.d/eclipse.yml
+++ b/index.d/eclipse.yml
@@ -1,16 +1,4 @@
 Projects:
-  - id: 1
-    app-id: eclipse
-    job-id: che-dev
-    git-url: https://github.com/dharmit/che-dockerfiles
-    git-branch: centos-dockerfiles
-    git-path: che-dev
-    target-file: Dockerfile.centos
-    desired-tag: latest
-    notify-email: shahdharmit@gmail.com
-    build-context: ./
-    depends-on: centos/centos:latest
-
   - id: 2
     app-id: eclipse
     job-id: che-launcher


### PR DESCRIPTION
This image is way outdated and keeps failing in the service. We don't have any users for it. ping @bamachrn 