### PR TITLE
Remove datamodel/gremlin:1.2.0 image from index

### DIFF
--- a/index.d/datamodel.yml
+++ b/index.d/datamodel.yml
@@ -10,17 +10,3 @@ Projects:
     notify-email: data-model-gremlin@googlegroups.com
     build-context: ./
     depends-on: centos/centos:7
-
-  - id: 2
-    app-id: datamodel
-    job-id: gremlin
-    git-url: https://github.com/containscafeine/data-model
-    git-branch: master
-    git-path: gremlin/
-    target-file: Dockerfile
-    desired-tag: 1.2.0
-    notify-email: data-model-gremlin@googlegroups.com
-    build-context: ./
-    depends-on:
-      - centos/centos:latest
-      - datamodel/centos-java:latest


### PR DESCRIPTION
This image is not being used anymore by datamodel team.

ping @msrb: does this look good?