### PR TITLE
Pipeline scanner for OpenShift MVP

### DIFF
--- a/index.d/dharmit.yaml
+++ b/index.d/dharmit.yaml
@@ -131,3 +131,15 @@ Projects:
     depends-on: openshift/jenkins-slave-base-centos7:latest
     build-context: ./
 
+  - id: 14
+    app-id: dharmit
+    job-id: pipeline-scanner
+    git-url: https://github.com/dharmit/pipeline-scanner
+    git-branch: master
+    git-path: /
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: shahdharmit@gmail.com
+    depends-on: centos/centos:latest
+    build-context: ./
+


### PR DESCRIPTION
atomic scanner installation's failing in my OpenShift setup due to [`docker run -it`](https://github.com/CentOS/container-pipeline-service/blob/master/atomic_scanners/pipeline-scanner/Dockerfile#L3). Can't change upstream scanner for MVP so created this fork for temporary use. PTAL @bamachrn 