### PR TITLE
Add pre-build hook for sclorg postgresql

### DIFF
--- a/index.d/centos.yaml
+++ b/index.d/centos.yaml
@@ -730,6 +730,8 @@ Projects:
     desired-tag: latest
     notify-email: hhorak@redhat.com
     build-context: ./
+    prebuild-script: hooks/pre_build_distgen
+    prebuild-context: /
     depends-on:
       - centos/centos:latest
 
@@ -743,6 +745,8 @@ Projects:
     desired-tag: latest
     notify-email: hhorak@redhat.com
     build-context: ./
+    prebuild-script: hooks/pre_build_distgen
+    prebuild-context: /
     depends-on:
       - centos/centos:latest
 
@@ -756,6 +760,8 @@ Projects:
     desired-tag: latest
     notify-email: hhorak@redhat.com
     build-context: ./
+    prebuild-script: hooks/pre_build_distgen
+    prebuild-context: /
     depends-on:
       - centos/centos:latest
 


### PR DESCRIPTION
Recently the sclorg postgresql image repository embraced distgen for source generation via https://github.com/sclorg/postgresql-container/pull/203

This PR modifies the index to run a pre-build hook that generates the sources before attempting to build the images.