### PR TITLE
add 6 tag for centos image

### DIFF
--- a/index.d/centos.yaml
+++ b/index.d/centos.yaml
@@ -1285,3 +1285,14 @@ Projects:
 
 # CentOS Atomic Base Image ends
 
+  - id: 148
+    app-id: centos
+    job-id: centos
+    git-url: https://github.com/CentOS/sig-cloud-instance-images
+    git-branch: CentOS-6
+    git-path: docker
+    target-file: Dockerfile
+    desired-tag: 6
+    notify-email: mohammed.zee1000@gmail.com
+    build-context: ./
+    depends-on: null

--- a/index.d/library.yaml
+++ b/index.d/library.yaml
@@ -50,3 +50,15 @@ Projects:
     notify-email: mohammed.zee1000@gmail.com
     build-context: ./
     depends-on: null
+
+  - id: 5
+    app-id: library
+    job-id: centos
+    git-url: https://github.com/CentOS/sig-cloud-instance-images
+    git-branch: CentOS-7
+    git-path: docker
+    target-file: Dockerfile
+    desired-tag: 7
+    notify-email: mohammed.zee1000@gmail.com
+    build-context: ./
+    depends-on: null

--- a/index.d/library.yaml
+++ b/index.d/library.yaml
@@ -62,3 +62,15 @@ Projects:
     notify-email: mohammed.zee1000@gmail.com
     build-context: ./
     depends-on: null
+
+  - id: 6
+    app-id: library
+    job-id: centos
+    git-url: https://github.com/CentOS/sig-cloud-instance-images
+    git-branch: CentOS-6
+    git-path: docker
+    target-file: Dockerfile
+    desired-tag: 6
+    notify-email: mohammed.zee1000@gmail.com
+    build-context: ./
+    depends-on: null


### PR DESCRIPTION
I noticed that `registry.centos.org/centos:7` exists, but `registry.centos.org/centos:6` doesn't.  This pull request should address that.  It also adds the `7` tag to `library.yaml` to match `centos.yaml`.