### PR TITLE
remove atomic-registry-intsall

### DIFF
--- a/index.d/projectatomic.yaml
+++ b/index.d/projectatomic.yaml
@@ -1,18 +1,4 @@
 Projects:
-  - id: 1 
-    app-id: projectatomic
-    job-id: atomic-registry-install
-    git-url: https://github.com/openshift/origin
-    git-branch: master
-    git-path: examples/atomic-registry/systemd
-    target-file: Dockerfile
-    desired-tag: latest
-    notify-email: aweiteka@redhat.com
-    build-context: ./
-    depends-on:
-      - centos/centos:latest 
-        #      - openshift/origin:latest
-
   - id: 2
     app-id: projectatomic
     job-id: cri-o


### PR DESCRIPTION
Atomic Registry has been deprecated.

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>