### PR TITLE
Add jfchevrette/origin-clients images

### DIFF
--- a/index.d/jfchevrette.yaml
+++ b/index.d/jfchevrette.yaml
@@ -1,0 +1,24 @@
+Projects:
+  - id: 1 
+    app-id: jfchevrette
+    job-id: origin-clients
+    git-url: https://github.com/jfchevrette/container-images
+    git-branch: master
+    git-path: origin-clients/3.9
+    target-file: Dockerfile
+    desired-tag: 3.9
+    notify-email: jfchevrette@gmail.com
+    build-context: ./
+    depends-on: centos/centos:7
+
+  - id: 2 
+    app-id: jfchevrette
+    job-id: origin-clients
+    git-url: https://github.com/jfchevrette/container-images
+    git-branch: master
+    git-path: origin-clients/3.7
+    target-file: Dockerfile
+    desired-tag: 3.7
+    notify-email: jfchevrette@gmail.com
+    build-context: ./
+    depends-on: centos/centos:7


### PR DESCRIPTION
I would like to add and maintain images of openshift origin clients based on centos/centos:7