### PR TITLE
Add sclorg/varnish 5 image + use prebuild script for distgen

### DIFF
--- a/index.d/centos.yaml
+++ b/index.d/centos.yaml
@@ -1191,10 +1191,11 @@ Projects:
     desired-tag: latest
     notify-email: hhorak@redhat.com
     build-context: ../
+    prebuild-script: hooks/pre_build_distgen
+    prebuild-context: /
     depends-on:
       - centos/centos:latest
       - centos/s2i-core-centos7:latest
-      - centos/s2i-base-centos7:latest
 
   - id: 142
     app-id: centos
@@ -1264,6 +1265,23 @@ Projects:
     notify-email: container-status-report@centos.org
     build-context: ./
     depends-on: centos/centos:latest
+
+  - id: 149
+    app-id: centos
+    job-id: varnish-5-centos7
+    git-url: https://github.com/sclorg/varnish-container.git
+    git-branch: master
+    git-path: 5/
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: hhorak@redhat.com
+    build-context: ../
+    prebuild-script: hooks/pre_build_distgen
+    prebuild-context: /
+    depends-on:
+      - centos/centos:latest
+      - centos/s2i-core-centos7:latest
+
 
 
 # List of SCLo SIG images ends


### PR DESCRIPTION
Varnish 5 image was released in RHSCL 3.1 in May 2018.

Also the repository started to use distgen for source generation via https://github.com/sclorg/varnish-container/pull/45. 
This PR modifies the index to run a pre-build hook that generates the sources before attempting to build the images. Similar to PR #311 for postgresql.

And both varnish 4 and 5 uses s2i-core as a base image (see [1] and [2]). So `depends-on` block can be cleaner.


[1] https://github.com/sclorg/varnish-container/blob/master/4/Dockerfile
[2] https://github.com/sclorg/varnish-container/blob/master/5/Dockerfile

