### PR TITLE
Re-add .yaml files that were removed instead of renamed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # Except what we need
 !.gitignore
 !README.md
-!cccp.yml
+!cccp.yaml
 !whattomerge.md
 !index.d
 index.d/*

--- a/cccp.yaml
+++ b/cccp.yaml
@@ -1,0 +1,11 @@
+# This file is required for the purpose of building a Docker container on CCCP.
+# More information (and a quickstart) found here: https://github.com/CentOS/container-index/pull/265
+
+# This will be part of the name of the container. It should match the job-id in index entry
+job-id: containername
+
+# This flag tells the container pipeline to skip user defined tests on their container
+# test-skip: False
+
+# This is path of the script that initiates the user defined tests. It must be able to return an exit code.
+# test-script: test-script.sh

--- a/index.d/index_template.yaml
+++ b/index.d/index_template.yaml
@@ -1,0 +1,27 @@
+# This is meant to be a template for your projects index.yml
+# Make a copy of this file and edit and DELETE THESE COMMENTS
+# The name of the file will determine the namespace of all
+# the containers for example hello.yml will mean all your
+# containers will be hello/job-id:desired-tag
+
+Projects:
+  - id: number
+    app-id: container_namespace
+    job-id: container_name
+    git-url: git_url
+    git-branch: master
+    git-path: git_path
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: youremail@example.com
+    build-context: ./
+    depends-on: null
+
+# If you have any dependant containers use this
+# Please check the other yml files for ids that are free
+#
+#   depends-on:
+#     - namespace1/container_name1:tag1
+#     - namespace2/container_name2:tag2
+#
+# Just copy paste for multiple entries


### PR DESCRIPTION
It seems that the template files have been removed when they were
supposed to be renamed from .yml to .yaml. With these files re-added,
the README.md makes more sense again.

Fixes: 5ab75d6445a644515ea1f37cf58663e7a9a892c9
Signed-off-by: Niels de Vos <ndevos@redhat.com>