### PR TITLE
Adds ccp-openshift-slave container to index

### DIFF
--- a/index.d/nshaikh.yaml
+++ b/index.d/nshaikh.yaml
@@ -1,0 +1,12 @@
+Projects:
+  - id: 1
+    app-id: nshaikh
+    job-id: ccp-openshift-slave
+    git-url: https://github.com/navidshaikh/containers-catalogue
+    git-branch: master
+    git-path: /ccp-openshift-slave
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: shaikhnavid14@gmail.com
+    depends-on: openshift/jenkins-slave-base-centos7:latest
+    build-context: ./


### PR DESCRIPTION
  This container is to be used for serving as openshift-slave
  and contains required scripts and binaries for building pipeline.