### PR TITLE
Add Jenkins image for pipeline service

### DIFF
--- a/index.d/pipeline-images.yaml
+++ b/index.d/pipeline-images.yaml
@@ -142,3 +142,15 @@ Projects:
     notify-email: bamachrn@gmail.com
     build-context: ./
     depends-on: centos/centos:latest
+
+  - id: 13
+    app-id: pipeline-images
+    job-id: jenkins-2-centos7
+    git-url: https://github.com/dharmit/jenkins
+    git-branch: master
+    git-path: 2/
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: shahdharmit@gmail.com
+    build-context: ./
+    depends-on: centos/centos:latest


### PR DESCRIPTION
This is to build our own Jenkins image for OpenShift architecture work. It will help us have a control over adding/removing plugins in Jenkins. Also we can set proper configuration parameters wherever required and have more control.