### PR TITLE
Add dotnet-21 container jobs

### DIFF
--- a/index.d/dotnet.yaml
+++ b/index.d/dotnet.yaml
@@ -37,3 +37,29 @@ Projects:
     build-context: ./
     depends-on:
        - openshift/jenkins-slave-base-centos7:latest
+
+  - id: 4
+    app-id: dotnet
+    job-id: dotnet-21-runtime-centos7
+    git-url: https://github.com/redhat-developer/s2i-dotnetcore
+    git-branch: master
+    git-path: 2.1/runtime
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: dotnet-team@redhat.com
+    build-context: ./
+    depends-on: centos/centos:latest
+
+  - id: 5
+    app-id: dotnet
+    job-id: dotnet-21-centos7
+    git-url: https://github.com/redhat-developer/s2i-dotnetcore
+    git-branch: master
+    git-path: 2.1/build
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: dotnet-team@redhat.com
+    build-context: ./
+    depends-on:
+       - centos/centos:latest
+       - dotnet/dotnet-21-runtime-centos7:latest


### PR DESCRIPTION
Dotnet 2.1 is now available on Centos, so we'd like to start building containers of it.

We should have a PR merged shortly updating the cccp.yml files in our s2i-dotnetcore repo to go along with this.