### PR TITLE
Bump ES version to 5.6.10

### DIFF
--- a/index.d/rhsyseng.yaml
+++ b/index.d/rhsyseng.yaml
@@ -95,6 +95,6 @@ Projects:
     git-branch  : 5.x
     target-file : Dockerfile.centos7
     notify-email: aos-aie@redhat.com
-    desired-tag : 5.5.2
+    desired-tag : 5.6.10
     build-context: ./
     depends-on  : centos/centos:7


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://github.com/RHsyseng/docker-rhel-elasticsearch/issues/46