### PR TITLE
Add Mattermost v5.2

### DIFF
--- a/index.d/mattermost.yaml
+++ b/index.d/mattermost.yaml
@@ -97,9 +97,21 @@ Projects:
     notify-email: akonarde@redhat.com
     build-context: ./
     depends-on: centos/centos:7
+    
+  - id: 9
+    app-id: mattermost
+    job-id: mattermost-team
+    git-url: https://github.com/rhdt/mattermost-openshift
+    git-branch: master
+    git-path: 5.2-PCP/
+    target-file: Dockerfile
+    desired-tag: 5.2-PCP
+    notify-email: akonarde@redhat.com
+    build-context: ./
+    depends-on: centos/centos:7
 
 # Matterbridge
-  - id: 9
+  - id: 10
     app-id: mattermost
     job-id: matterbridge
     git-url: https://github.com/rhdt/matterbridge
@@ -111,7 +123,7 @@ Projects:
     build-context: ./
     depends-on: centos/centos:7
 
-  - id: 10
+  - id: 11
     app-id: mattermost
     job-id: matterbridge
     git-url: https://github.com/rhdt/matterbridge
@@ -123,7 +135,7 @@ Projects:
     build-context: ./
     depends-on: centos/centos:7
 
-  - id: 11
+  - id: 12
     app-id: mattermost
     job-id: matterbridge
     git-url: https://github.com/rhdt/matterbridge
@@ -138,7 +150,7 @@ Projects:
 
 # Mattermost Push proxy
 
-  - id: 12
+  - id: 13
     app-id: mattermost
     job-id: mattermost-push-proxy
     git-url: https://github.com/rhdt/mm-push-proxy
@@ -150,7 +162,7 @@ Projects:
     build-context: ./
     depends-on: centos/centos:7
     
-  - id: 13
+  - id: 14
     app-id: mattermost
     job-id: mattermost-push-proxy
     git-url: https://github.com/rhdt/mm-push-proxy
@@ -165,7 +177,7 @@ Projects:
 # Integrations: 
 
 # Mattermost Gitlab Integration
-  - id: 14
+  - id: 15
     app-id: mattermost
     job-id: mattermost-gitlab-integration
     git-url: https://github.com/rhdt/mattermost-gitlab-integration
@@ -178,7 +190,7 @@ Projects:
     depends-on: centos/centos:7
 
 # Mattermost Trello Integration
-  - id: 15
+  - id: 16
     app-id: mattermost
     job-id: mattermost-trello-integration
     git-url: https://github.com/rhdt/mattermost-trello-integration
@@ -191,7 +203,7 @@ Projects:
     depends-on: centos/centos:latest
     
 # Mattermost RSS Integration
-  - id: 16
+  - id: 17
     app-id: mattermost
     job-id: mattermost-rss-integration
     git-url: https://github.com/rhdt/Rss-Atom-Feed-Integration-for-Mattermost
@@ -204,7 +216,7 @@ Projects:
     depends-on: centos/centos:7
 
 # Mattermost Github integration
-  - id: 17
+  - id: 18
     app-id: mattermost
     job-id: mattermost-github-integration
     git-url: https://github.com/rhdt/mattermost-github-integration
@@ -219,7 +231,7 @@ Projects:
 # Miscellaneous
 
 # recurring-pgdump
-  - id: 18
+  - id: 19
     app-id: mattermost
     job-id: recurring-pgdump
     git-url: https://github.com/rhdt/recurring-pgdump
@@ -232,7 +244,7 @@ Projects:
     depends-on: centos/centos:latest
 
 # nginx-redirector
-  - id: 19
+  - id: 20
     app-id: mattermost
     job-id: nginx-redirector
     git-url: https://github.com/jfchevrette/nginx-redirector
@@ -245,7 +257,7 @@ Projects:
     depends-on: kbsingh/openshift-nginx:latest
 
 # Penfold
-  - id: 20
+  - id: 21
     app-id: mattermost
     job-id: penfold
     git-url: https://github.com/gorkem/penfold


### PR DESCRIPTION
Release notes: https://docs.mattermost.com/administration/changelog.html#release-v5-2
Build directory: https://github.com/rhdt/mattermost-openshift/tree/master/5.2-PCP