### PR TITLE
Fixing slave image index entry so it passes CI.

### DIFF
--- a/index.d/pipeline-images.yaml
+++ b/index.d/pipeline-images.yaml
@@ -173,9 +173,9 @@ Projects:
     job-id: ccp-openshift-slave
     git-url: https://github.com/CentOS/container-pipeline-service
     git-branch: openshift
-    git-path: /
-    target-file: Dockerfiles/ccp-openshift-slave/Dockerfile
+    git-path: /Dockerfiles/ccp-openshift-slave
+    target-file: Dockerfile
     desired-tag: latest
     notify-email: shahdharmit@gmail.com
     depends-on: openshift/jenkins-slave-base-centos7:latest
-    build-context: ./
+    build-context: ../../


### PR DESCRIPTION
Git path is where it looks for target file as well as
cccp.yaml. So build-context should be used instead
to get stuff outside into build.

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>