### PR TITLE
No need to build individual ccp-openshift-slave image anymore

### DIFF
--- a/index.d/dharmit.yaml
+++ b/index.d/dharmit.yaml
@@ -121,18 +121,6 @@ Projects:
 
   - id: 13
     app-id: dharmit
-    job-id: ccp-openshift-slave
-    git-url: https://github.com/dharmit/dockerfiles
-    git-branch: master
-    git-path: /ccp-openshift-slave
-    target-file: Dockerfile
-    desired-tag: latest
-    notify-email: shahdharmit@gmail.com
-    depends-on: openshift/jenkins-slave-base-centos7:latest
-    build-context: ./
-
-  - id: 14
-    app-id: dharmit
     job-id: pipeline-scanner
     git-url: https://github.com/dharmit/pipeline-scanner
     git-branch: master


### PR DESCRIPTION
In the new architecture of the service, we can easily build image based off our code and push it to internal registry so that dev/pre-prod deployments use that image instead. In fact, that's the best way to ensure that we use code that we're writing. So, this image is not longer needed to be build on r.c.o.