### PR TITLE
Removes ccp-openshift-scan image from pipeline-images namespace

### DIFF
--- a/index.d/navidshaikh.yaml
+++ b/index.d/navidshaikh.yaml
@@ -2,8 +2,8 @@ Projects:
   - id: 1
     app-id: navidshaikh
     job-id: ccp-openshift-scan
-    git-url: https://github.com/navidshaikh/ccp-openshift
-    git-branch: master
+    git-url: https://github.com/navidshaikh/container-pipeline-service
+    git-branch: with-daemon-set
     git-path: /Dockerfiles/ccp-openshift-scan/
     target-file: Dockerfile
     desired-tag: latest

--- a/index.d/pipeline-images.yaml
+++ b/index.d/pipeline-images.yaml
@@ -158,18 +158,6 @@ Projects:
 
   - id: 14
     app-id: pipeline-images
-    job-id: ccp-openshift-scan
-    git-url: https://github.com/CentOS/container-pipeline-service
-    git-branch: openshift
-    git-path: /Dockerfiles/ccp-openshift-scan
-    target-file: Dockerfile
-    desired-tag: latest
-    notify-email: shaikhnavid14@gmail.com
-    depends-on: centos/centos:latest
-    build-context: ./
-
-  - id: 15
-    app-id: pipeline-images
     job-id: ccp-openshift-slave
     git-url: https://github.com/CentOS/container-pipeline-service
     git-branch: openshift


### PR DESCRIPTION
  and keeps it under navidshaikh namespace for time being to keep
  the image around for failover.