### PR TITLE
Fixes build context for api-server container

### DIFF
--- a/index.d/navidshaikh.yaml
+++ b/index.d/navidshaikh.yaml
@@ -21,4 +21,4 @@ Projects:
     desired-tag: latest
     notify-email: shaikhnavid14@gmail.com
     depends-on: centos/centos:latest
-    build-context: ./
+    build-context: ../../


### PR DESCRIPTION
 since the Dockerfile path is relative to git-path and COPY
 source references are made from the root of the directory.