### PR TITLE
Add mattermost v5.3 and v5.4

### DIFF
--- a/index.d/mattermost.yaml
+++ b/index.d/mattermost.yaml
@@ -110,8 +110,32 @@ Projects:
     build-context: ./
     depends-on: centos/centos:7
 
-# Matterbridge
   - id: 10
+    app-id: mattermost
+    job-id: mattermost-team
+    git-url: https://github.com/rhdt/mattermost-openshift
+    git-branch: master
+    git-path: 5.3-PCP/
+    target-file: Dockerfile
+    desired-tag: 5.3-PCP
+    notify-email: akonarde@redhat.com
+    build-context: ./
+    depends-on: centos/centos:7
+
+  - id: 11
+    app-id: mattermost
+    job-id: mattermost-team
+    git-url: https://github.com/rhdt/mattermost-openshift
+    git-branch: master
+    git-path: 5.4-PCP/
+    target-file: Dockerfile
+    desired-tag: 5.4-PCP
+    notify-email: akonarde@redhat.com
+    build-context: ./
+    depends-on: centos/centos:7
+
+# Matterbridge
+  - id: 12
     app-id: mattermost
     job-id: matterbridge
     git-url: https://github.com/rhdt/matterbridge
@@ -123,7 +147,7 @@ Projects:
     build-context: ./
     depends-on: centos/centos:7
 
-  - id: 11
+  - id: 13
     app-id: mattermost
     job-id: matterbridge
     git-url: https://github.com/rhdt/matterbridge
@@ -135,7 +159,7 @@ Projects:
     build-context: ./
     depends-on: centos/centos:7
 
-  - id: 12
+  - id: 14
     app-id: mattermost
     job-id: matterbridge
     git-url: https://github.com/rhdt/matterbridge
@@ -147,7 +171,7 @@ Projects:
     build-context: ./
     depends-on: centos/centos:7
 
-  - id: 13
+  - id: 15
     app-id: mattermost
     job-id: matterbridge
     git-url: https://github.com/rhdt/matterbridge
@@ -161,7 +185,7 @@ Projects:
 
 # Mattermost Push proxy
 
-  - id: 14
+  - id: 16
     app-id: mattermost
     job-id: mattermost-push-proxy
     git-url: https://github.com/rhdt/mm-push-proxy
@@ -173,7 +197,7 @@ Projects:
     build-context: ./
     depends-on: centos/centos:7
     
-  - id: 15
+  - id: 17
     app-id: mattermost
     job-id: mattermost-push-proxy
     git-url: https://github.com/rhdt/mm-push-proxy
@@ -188,7 +212,7 @@ Projects:
 # Integrations: 
 
 # Mattermost Gitlab Integration
-  - id: 16
+  - id: 18
     app-id: mattermost
     job-id: mattermost-gitlab-integration
     git-url: https://github.com/rhdt/mattermost-gitlab-integration
@@ -201,7 +225,7 @@ Projects:
     depends-on: centos/centos:7
 
 # Mattermost Trello Integration
-  - id: 17
+  - id: 19
     app-id: mattermost
     job-id: mattermost-trello-integration
     git-url: https://github.com/rhdt/mattermost-trello-integration
@@ -214,7 +238,7 @@ Projects:
     depends-on: centos/centos:latest
     
 # Mattermost RSS Integration
-  - id: 18
+  - id: 20
     app-id: mattermost
     job-id: mattermost-rss-integration
     git-url: https://github.com/rhdt/Rss-Atom-Feed-Integration-for-Mattermost
@@ -227,7 +251,7 @@ Projects:
     depends-on: centos/centos:7
 
 # Mattermost Github integration
-  - id: 19
+  - id: 21
     app-id: mattermost
     job-id: mattermost-github-integration
     git-url: https://github.com/rhdt/mattermost-github-integration
@@ -242,7 +266,7 @@ Projects:
 # Miscellaneous
 
 # recurring-pgdump
-  - id: 20
+  - id: 22
     app-id: mattermost
     job-id: recurring-pgdump
     git-url: https://github.com/rhdt/recurring-pgdump
@@ -255,7 +279,7 @@ Projects:
     depends-on: centos/centos:latest
 
 # nginx-redirector
-  - id: 21
+  - id: 23
     app-id: mattermost
     job-id: nginx-redirector
     git-url: https://github.com/jfchevrette/nginx-redirector
@@ -268,7 +292,7 @@ Projects:
     depends-on: kbsingh/openshift-nginx:latest
 
 # Penfold
-  - id: 22
+  - id: 24
     app-id: mattermost
     job-id: penfold
     git-url: https://github.com/gorkem/penfold


### PR DESCRIPTION
Bump mattermost versions
Changelogs available here: https://docs.mattermost.com/administration/changelog.html

Added the source repo folders via this PR: https://github.com/rhdt/mattermost-openshift/pull/26