### PR TITLE
Change golang image tag for the image dharmit/golang

### DIFF
--- a/index.d/dharmit.yaml
+++ b/index.d/dharmit.yaml
@@ -54,7 +54,7 @@ Projects:
     git-branch: master
     git-path: /golang/1.8/
     target-file: Dockerfile
-    desired-tag: 1.8
+    desired-tag: latest
     notify-email: shahdharmit@gmail.com
     build-context: ./
     depends-on: dharmit/base:latest


### PR DESCRIPTION
Change the tag from `1.8` to `latest` since we're not installing a specific version of Go in the image but installing the latest available in the repos.