### PR TITLE
Adding 'centos-quarkus.io-jdk8' stack to container-index

### DIFF
--- a/index.d/che-stacks.yaml
+++ b/index.d/che-stacks.yaml
@@ -131,3 +131,14 @@ Projects:
     build-context: ./
     depends-on: che-stacks/centos-stack-base:latest
 
+  - id: 13
+    app-id: che-stacks
+    job-id: centos-quarkus.io-jdk8
+    git-url: https://github.com/eclipse/che-dockerfiles
+    git-branch: master
+    git-path: recipes/centos_quarkus.io_jdk8
+    target-file: Dockerfile
+    desired-tag: latest
+    notify-email: vorburger@redhat.com
+    build-context: ./
+    depends-on: che-stacks/centos-jdk8:latest


### PR DESCRIPTION
Related che PR https://github.com/eclipse/che-dockerfiles/pull/240
Related rh-che PR - https://github.com/redhat-developer/che-dockerfiles/pull/54