### PR TITLE
Update depends-on for dlrnapi container

### DIFF
--- a/index.d/softwarefactory-project.yaml
+++ b/index.d/softwarefactory-project.yaml
@@ -9,4 +9,4 @@ Projects:
     desired-tag: latest
     notify-email: jpena@redhat.com
     build-context: ./
-    depends-on: centos/centos:7
+    depends-on: centos/centos:8


### PR DESCRIPTION
It now depends on centos:8 instead of centos:7.